### PR TITLE
Upgrade to Jackson 2.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-base</artifactId>
-        <version>2.9.5</version>
+        <version>2.10.3</version>
     </parent>
     <groupId>org.openapitools</groupId>
     <artifactId>jackson-databind-nullable</artifactId>


### PR DESCRIPTION
Jackson 2.9.x is in maintenance mode and will only receive security fixes until Jackson 2.11 has been released (which should happen in April).

In order to stay on top of the upgrade cycle, jackson-databind-nullable should use the latest stable version of Jackson.