### PR TITLE
Add ifPresent action on JsonNullable

### DIFF
--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
@@ -2,6 +2,7 @@ package org.openapitools.jackson.nullable;
 
 import java.io.Serializable;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 public class JsonNullable<T> implements Serializable {
 
@@ -66,6 +67,20 @@ public class JsonNullable<T> implements Serializable {
 
     public boolean isPresent() {
         return isPresent;
+    }
+
+    /**
+     * If a value is present, performs the given action with the value,
+     * otherwise does nothing.
+     *
+     * @param action the action to be performed, if a value is present
+     */
+    public void ifPresent(
+            Consumer<? super T> action) {
+
+        if (this.isPresent) {
+            action.accept(value);
+        }
     }
 
     @Override

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableModule.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableModule.java
@@ -1,6 +1,7 @@
 package org.openapitools.jackson.nullable;
 
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.databind.Module;
 
 public class JsonNullableModule extends Module {

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
@@ -58,6 +58,30 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
+    public void ifPresentWithValueNotPresent() {
+        JsonNullable<String> test = JsonNullable.undefined();
+        test.ifPresent(string -> {
+            throw new RuntimeException();
+        });
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void ifPresentWithNullValuePresent() {
+        JsonNullable<String> test = JsonNullable.of(null);
+        test.ifPresent(string -> {
+            throw new RuntimeException();
+        });
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void ifPresentWithNonNullValuePresent() {
+        JsonNullable<String> test = JsonNullable.of("test");
+        test.ifPresent(string -> {
+            throw new RuntimeException();
+        });
+    }
+
+    @Test
     public void serializeNonBeanProperty() throws JsonProcessingException {
         assertEquals("null", mapper.writeValueAsString(JsonNullable.of(null)));
         assertEquals("\"foo\"", mapper.writeValueAsString(JsonNullable.of("foo")));


### PR DESCRIPTION
Hi,

First, thanks for this module which I think is clearer than the optional.empty() or the optionnal == null when checking the absence of a properties in a json payload.

After using the JsonNullable, I notice that 80% of our usages was to call a setter and pass the value of the same type. Therefore, I was wondering if having a `ifPresent` (like the optional) could be a good idea. 

With the ifPresent, now something like 
```
        if (jsonObject.value1.isPresent()) {
            entity.setValue1(jsonObject.value1.get());
        }
```

Now become:
```
jsonObject.value1.ifPresent(entity::setValue1);
```



