### PR TITLE
upgrade jackson-base to 2.10.3 for vulnerability CVE-2020-35491

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-base</artifactId>
-        <version>2.10.3</version>
+        <version>2.12.2</version>
     </parent>
     <groupId>org.openapitools</groupId>
     <artifactId>jackson-databind-nullable</artifactId>


### PR DESCRIPTION
fixes #21 
CVE for reference: https://nvd.nist.gov/vuln/detail/CVE-2020-35491