### PR TITLE
Include license in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,13 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <properties>
         <!-- Generate PackageVersion.java into this directory. -->


### PR DESCRIPTION
The license should be specified also in POM. This enables Maven Central Repository to correctly state license and also is important for using for example org.codehaus.mojo:license-maven-plugin to check ones own project using the jackson-databind-nullable dependency.