### PR TITLE
jackson-base 2.13.2.1, add getAbsentValue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-base</artifactId>
-        <version>2.12.2</version>
+        <version>2.13.2.1</version>
     </parent>
     <groupId>org.openapitools</groupId>
     <artifactId>jackson-databind-nullable</artifactId>

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializer.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializer.java
@@ -58,6 +58,11 @@ public class JsonNullableDeserializer extends ReferenceTypeDeserializer<JsonNull
     }
 
     @Override
+    public Object getAbsentValue(DeserializationContext ctxt) {
+        return JsonNullable.undefined();
+    }
+
+    @Override
     public JsonNullable<Object> getNullValue(DeserializationContext ctxt) {
         return JsonNullable.of(null);
     }


### PR DESCRIPTION
Upgrade jackson-base from 2.12.2 to 2.13.2.1.

Add JsonNullableDeserializer#getAbsentValue(DeserializationContext)
to overwrite the method inherited from JsonDeserializer.

Fixes #30