### PR TITLE
Updating version of jackson-databind due to high level vulnaribility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>org/openapitools/jackson/nullable</packageVersion.dir>
         <packageVersion.package>${project.groupId}.jackson.nullable</packageVersion.package>
+        <jackson.version>2.14.0-rc2</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hello!

I have created PR for updating jackson-databind version due to a high level [vulnerability](https://avd.aquasec.com/nvd/2022/cve-2022-42003/) 

This update needs by the open-source projects

Thank you!