### PR TITLE
Add "Automatic-Module-Name" to manifest, fix usage as java 9+ module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,17 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openapitools.jackson.nullable</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Fixes #40