### PR TITLE
Add support for jakarta-validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <version>2.0.1.Final</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
             <version>6.2.5.Final</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.1-b09</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableJakartaValueExtractor.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableJakartaValueExtractor.java
@@ -3,7 +3,6 @@ package org.openapitools.jackson.nullable;
 import jakarta.validation.valueextraction.ExtractedValue;
 import jakarta.validation.valueextraction.UnwrapByDefault;
 import jakarta.validation.valueextraction.ValueExtractor;
-import java.util.Collection;
 
 /**
  * Extractor for JsonNullable (modern jakarta-validation version)
@@ -12,17 +11,6 @@ import java.util.Collection;
 public class JsonNullableJakartaValueExtractor implements ValueExtractor<JsonNullable<@ExtractedValue ?>> {
     @Override
     public void extractValues(JsonNullable<?> originalValue, ValueReceiver receiver) {
-        if (originalValue.isPresent()) {
-            Object unwrapped = originalValue.get();
-            if (unwrapped instanceof Collection<?>) {
-                Collection<?> unwrappedList = (Collection<?>) unwrapped;
-                Object[] objects = unwrappedList.toArray();
-                for (int i = 0; i < objects.length; i++) {
-                    receiver.indexedValue("<list element>", i, objects[i]);
-                }
-            } else {
-                receiver.value(null, originalValue.get());
-            }
-        }
+        JsonNullableValueExtractorHelper.extractValues(originalValue, receiver::indexedValue, receiver::value);
     }
 }

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableJakartaValueExtractor.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableJakartaValueExtractor.java
@@ -1,15 +1,15 @@
 package org.openapitools.jackson.nullable;
 
-import javax.validation.valueextraction.ExtractedValue;
-import javax.validation.valueextraction.UnwrapByDefault;
-import javax.validation.valueextraction.ValueExtractor;
+import jakarta.validation.valueextraction.ExtractedValue;
+import jakarta.validation.valueextraction.UnwrapByDefault;
+import jakarta.validation.valueextraction.ValueExtractor;
 import java.util.Collection;
 
 /**
- * Extractor for JsonNullable (classic javax-validation version)
+ * Extractor for JsonNullable (modern jakarta-validation version)
  */
 @UnwrapByDefault
-public class JsonNullableValueExtractor implements ValueExtractor<JsonNullable<@ExtractedValue ?>> {
+public class JsonNullableJakartaValueExtractor implements ValueExtractor<JsonNullable<@ExtractedValue ?>> {
     @Override
     public void extractValues(JsonNullable<?> originalValue, ValueReceiver receiver) {
         if (originalValue.isPresent()) {

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableValueExtractor.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableValueExtractor.java
@@ -3,7 +3,6 @@ package org.openapitools.jackson.nullable;
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.UnwrapByDefault;
 import javax.validation.valueextraction.ValueExtractor;
-import java.util.Collection;
 
 /**
  * Extractor for JsonNullable (classic javax-validation version)
@@ -12,17 +11,6 @@ import java.util.Collection;
 public class JsonNullableValueExtractor implements ValueExtractor<JsonNullable<@ExtractedValue ?>> {
     @Override
     public void extractValues(JsonNullable<?> originalValue, ValueReceiver receiver) {
-        if (originalValue.isPresent()) {
-            Object unwrapped = originalValue.get();
-            if (unwrapped instanceof Collection<?>) {
-                Collection<?> unwrappedList = (Collection<?>) unwrapped;
-                Object[] objects = unwrappedList.toArray();
-                for (int i = 0; i < objects.length; i++) {
-                    receiver.indexedValue("<list element>", i, objects[i]);
-                }
-            } else {
-                receiver.value(null, originalValue.get());
-            }
-        }
+        JsonNullableValueExtractorHelper.extractValues(originalValue, receiver::indexedValue, receiver::value);
     }
 }

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorHelper.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorHelper.java
@@ -1,0 +1,30 @@
+package org.openapitools.jackson.nullable;
+
+import java.util.Collection;
+
+abstract class JsonNullableValueExtractorHelper {
+    public static void extractValues(JsonNullable<?> originalValue, IndexedValueSetter indexedValueSetter, ValueSetter valueSetter) {
+        if (originalValue.isPresent()) {
+            Object unwrapped = originalValue.get();
+            if (unwrapped instanceof Collection<?>) {
+                Collection<?> unwrappedList = (Collection<?>) unwrapped;
+                Object[] objects = unwrappedList.toArray();
+                for (int i = 0; i < objects.length; i++) {
+                    indexedValueSetter.apply("<list element>", i, objects[i]);
+                }
+            } else {
+                valueSetter.apply(null, originalValue.get());
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface IndexedValueSetter {
+        void apply(String var1, int var2, Object var3);
+    }
+
+    @FunctionalInterface
+    interface ValueSetter {
+        void apply(String var1, Object var2);
+    }
+}

--- a/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
+++ b/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
@@ -1,0 +1,1 @@
+org.openapitools.jackson.nullable.JsonNullableJakartaValueExtractor

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
@@ -1,5 +1,7 @@
 package org.openapitools.jackson.nullable;
 
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,13 +19,21 @@ import static org.junit.Assert.assertTrue;
 
 
 public class JsonNullableValueExtractorTest {
-
+    private ValidatorFactory factory;
     private Validator validator;
 
     @Before
     public void setUp() {
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory();
         validator = factory.getValidator();
+    }
+
+    @After
+    public void tearDown() {
+        factory.close();
     }
 
     @Test

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
@@ -35,8 +35,8 @@ public class JsonNullableValueExtractorTest {
         final UnitIssue2 unitIssue2 = new UnitIssue2();
         unitIssue2.setRestrictedString("a >15 character long string");
         unitIssue2.setNullableRestrictedString("a >15 character long string");
-        unitIssue2.setRestrictedInt(Integer.valueOf(16));
-        unitIssue2.setNullableRestrictedInt(Integer.valueOf(16));
+        unitIssue2.setRestrictedInt(16);
+        unitIssue2.setNullableRestrictedInt(16);
 
         final Set<ConstraintViolation<UnitIssue2>> validate = validator.validate(unitIssue2);
 

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
@@ -1,7 +1,6 @@
 package org.openapitools.jackson.nullable;
 
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,21 +18,16 @@ import static org.junit.Assert.assertTrue;
 
 
 public class JsonNullableValueExtractorTest {
-    private ValidatorFactory factory;
     private Validator validator;
 
     @Before
     public void setUp() {
-        factory = Validation.byDefaultProvider()
+        try (ValidatorFactory factory = Validation.byDefaultProvider()
                 .configure()
                 .messageInterpolator(new ParameterMessageInterpolator())
-                .buildValidatorFactory();
-        validator = factory.getValidator();
-    }
-
-    @After
-    public void tearDown() {
-        factory.close();
+                .buildValidatorFactory()) {
+            validator = factory.getValidator();
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for jakarta-validation (fixes #39)

I've not managed to get the tests running for jakarta and javax in parallel as hibernate-validator supported only either of them (6.2.5.Final vs 8.0.0.Final)