### PR TITLE
Add JsonNullableIsPresent annotation and validator

### DIFF
--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableIsPresent.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableIsPresent.java
@@ -1,0 +1,15 @@
+package org.openapitools.jackson.nullable;
+
+import javax.validation.*;
+import java.lang.annotation.*;
+
+@Constraint(validatedBy = JsonNullableIsPresentValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonNullableIsPresent {
+    String message() default "must be present";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableIsPresentValidator.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableIsPresentValidator.java
@@ -1,0 +1,17 @@
+package org.openapitools.jackson.nullable;
+
+import javax.validation.*;
+
+public class JsonNullableIsPresentValidator implements ConstraintValidator<JsonNullableIsPresent, JsonNullable<?>> {
+    @Override
+    public void initialize(JsonNullableIsPresent constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(JsonNullable<?> jsonNullable, ConstraintValidatorContext constraintValidatorContext) {
+        if (jsonNullable == null) {
+            return true;
+        }
+        return jsonNullable.isPresent();
+    }
+}

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullablIsPresentValidatorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullablIsPresentValidatorTest.java
@@ -1,0 +1,75 @@
+package org.openapitools.jackson.nullable;
+
+import org.hibernate.validator.messageinterpolation.*;
+import org.junit.*;
+
+import javax.validation.*;
+import javax.validation.valueextraction.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+
+public class JsonNullablIsPresentValidatorTest {
+    private Validator validator;
+
+    @Before
+    public void setUp() {
+        try (ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    public void testIsValid_whenJsonNullableWithValue() {
+        final TestBean bean = new TestBean(JsonNullable.of("value"));
+
+        final Set<ConstraintViolation<TestBean>> validate = validator.validate(bean);
+
+        assertEquals(0, validate.size());
+    }
+
+    @Test
+    public void testIsValid_whenJsonNullableWithNull() {
+        final TestBean bean = new TestBean(JsonNullable.of(null));
+
+        final Set<ConstraintViolation<TestBean>> validate = validator.validate(bean);
+
+        assertEquals(0, validate.size());
+    }
+
+    @Test
+    public void testIsNotValid_whenJsonNullableUndefined() {
+        final TestBean bean = new TestBean(JsonNullable.undefined());
+
+        final Set<ConstraintViolation<TestBean>> validate = validator.validate(bean);
+
+        assertEquals(1, validate.size());
+        final ConstraintViolation<TestBean> violation = validate.iterator().next();
+        assertEquals("must be present", violation.getMessage());
+    }
+
+    @Test
+    public void testIsValid_whenNull() {
+        final TestBean bean = new TestBean(null);
+
+        final Set<ConstraintViolation<TestBean>> validate = validator.validate(bean);
+
+        assertEquals(0, validate.size());
+    }
+
+    static class TestBean {
+
+        @JsonNullableIsPresent(payload = Unwrapping.Skip.class)
+        public JsonNullable<String> value;
+
+        public TestBean(JsonNullable<String> value) {
+            this.value = value;
+        }
+    }
+
+
+}


### PR DESCRIPTION
Adds a `@JsonNullableIsPresent` constraint based on [openapi-generator issue 11969](https://github.com/OpenAPITools/openapi-generator/issues/11969#issuecomment-1084351433).

There's an immedate use for `@JsonNullableIsPresent` on a project I'm working on and I was also planning to raise a PR to fix [openapi-generator issue 11969](https://github.com/OpenAPITools/openapi-generator/issues/11969) by adding the new annotation to the `{#required}` block in `beanValidation.mustache`.
