### PR TITLE
Bumps version to 0.2.7-SNAPSHOT and bumps parent version to 2.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-base</artifactId>
-        <version>2.14.0-rc2</version>
+        <version>2.18.2</version>
     </parent>
     <groupId>org.openapitools</groupId>
     <artifactId>jackson-databind-nullable</artifactId>
     <packaging>jar</packaging>
     <name>JsonNullable Jackson module</name>
     <description>JsonNullable wrapper class and Jackson module to support fields with meaningful null values.</description>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
 
     <url>https://github.com/OpenAPITools/jackson-databind-nullable</url>
     <scm>
@@ -61,6 +61,11 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>6.2.5.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Also adds JUnit 4 as a dependency as it is no longer provided by the parent.

The current latest release 0.2.6 depends on Jackson 2.14.0, which is not compatible with 2.15.0+, which means you must exclude the transitive jackson dependencies if you depend og jackson-databind-nullable.

Please consider releasing this as 0.2.7