### PR TITLE
Build as multi release jar

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,32 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-java-8</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-java-9</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -93,7 +115,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.openapitools.jackson.nullable</Automatic-Module-Name>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
+                            <release>8</release>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -4,4 +4,8 @@ module org.openapitools.jackson.nullable {
     requires static java.validation;
 
     exports org.openapitools.jackson.nullable;
+
+    provides com.fasterxml.jackson.databind.Module with org.openapitools.jackson.nullable.JsonNullableModule;
+    provides javax.validation.valueextraction.ValueExtractor with org.openapitools.jackson.nullable.JsonNullableValueExtractor;
+    provides jakarta.validation.valueextraction.ValueExtractor with org.openapitools.jackson.nullable.JsonNullableJakartaValueExtractor;
 }

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,7 @@
+module org.openapitools.jackson.nullable {
+    requires com.fasterxml.jackson.databind;
+    requires static jakarta.validation;
+    requires static java.validation;
+
+    exports org.openapitools.jackson.nullable;
+}


### PR DESCRIPTION
As mentioned in #61 here is the build config to build this as a multi release jar with a `module-info.java` for Java 9+. This allows using this dependency with JLink while maintaining support for Java 8.

- update GitHub Action to use JDK 11
- added module info in `java9` source folder
- added executions for java 8 and 9
- removed automatic module
- added multi release entry to manifest