### PR TITLE
Remove Javadoc argument --ignore-source-errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
                     <quiet>true</quiet>
                     <additionalOptions>
                         <additionalOption>-Xdoclint:none</additionalOption>
-                        <additionalOption>--ignore-source-errors</additionalOption>
                     </additionalOptions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The --ignore-source-errors argument is making Javadoc fail with JDK 8.  This PR removes that argument.