### PR TITLE
Skip SNAPSHOT deploy job on forks

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -51,6 +51,7 @@ jobs:
         run: mvn -B test
 
   publish-OSSRH:
+    if: github.repository == 'OpenAPITools/jackson-databind-nullable'
     runs-on: ubuntu-latest
     name: Publish to Maven Central
     needs: test


### PR DESCRIPTION
This PR prevents forks from trying to run the publish-OSSRH job.