### PR TITLE
Update to JUnit 5 and fix tests

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: 'temurin'
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and Test
+        run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/openapitools/jackson/nullable/ContextualJsonNullableTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/ContextualJsonNullableTest.java
@@ -3,12 +3,15 @@ package org.openapitools.jackson.nullable;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-public class ContextualJsonNullableTest extends ModuleTestBase
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContextualJsonNullableTest extends ModuleTestBase
 {
     // [datatypes-java8#17]
     @JsonPropertyOrder({ "date", "date1", "date2" })
@@ -29,7 +32,8 @@ public class ContextualJsonNullableTest extends ModuleTestBase
     /**********************************************************
      */
 
-    public void testContextualJsonNullables() throws Exception
+    @Test
+    void testContextualJsonNullables() throws Exception
     {
         final ObjectMapper mapper = mapperWithModule();
         SimpleDateFormat df = new SimpleDateFormat("yyyy/MM/dd");

--- a/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
@@ -3,11 +3,14 @@ package org.openapitools.jackson.nullable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 // TODO: fix JsonNullable in constructor annotated by JsonCreator
-@Ignore("JsonNullable in a constructor is dederialized to JsonNullable[null] instead of JsonNullable.undefined")
-public class CreatorTest extends ModuleTestBase
+@Disabled("JsonNullable in a constructor is dederialized to JsonNullable[null] instead of JsonNullable.undefined")
+class CreatorTest extends ModuleTestBase
 {
     static class CreatorWithJsonNullableStrings
     {
@@ -35,7 +38,8 @@ public class CreatorTest extends ModuleTestBase
      * Test to ensure that creator parameters use defaulting
      * (introduced in Jackson 2.6)
      */
-    public void testCreatorWithJsonNullable() throws Exception
+    @Test
+    void testCreatorWithJsonNullable() throws Exception
     {
         CreatorWithJsonNullableStrings bean = MAPPER.readValue(
                 aposToQuotes("{'a':'foo'}"), CreatorWithJsonNullableStrings.class);

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullJacksonServiceLoadingTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullJacksonServiceLoadingTest.java
@@ -2,11 +2,14 @@ package org.openapitools.jackson.nullable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class JsonNullJacksonServiceLoadingTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-    public void testJacksonJsonNullableModuleServiceLoading() {
+class JsonNullJacksonServiceLoadingTest {
+
+    @Test
+    void testJacksonJsonNullableModuleServiceLoading() {
         String foundModuleName = ObjectMapper.findModules().get(0).getModuleName();
         assertEquals(new JsonNullableModule().getModuleName(), foundModuleName);
     }

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
@@ -2,8 +2,12 @@ package org.openapitools.jackson.nullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
-public class JsonNullWithEmptyTest  extends ModuleTestBase
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JsonNullWithEmptyTest  extends ModuleTestBase
 {
     private final ObjectMapper MAPPER = mapperWithModule();
 
@@ -16,14 +20,15 @@ public class JsonNullWithEmptyTest  extends ModuleTestBase
         }
     }
 
-    public void testJsonNullableFromEmpty() throws Exception {
+    @Test
+    void testJsonNullableFromEmpty() throws Exception {
         JsonNullable<?> value = MAPPER.readValue(quote(""), new TypeReference<JsonNullable<Integer>>() {});
         assertFalse(value.isPresent());
     }
 
     // for [datatype-jdk8#23]
-    public void testBooleanWithEmpty() throws Exception
-    {
+    @Test
+    void testBooleanWithEmpty() throws Exception {
         // and looks like a special, somewhat non-conforming case is what a user had
         // issues with
         BooleanBean b = MAPPER.readValue(aposToQuotes("{'value':''}"), BooleanBean.class);

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class JsonNullableBasicTest extends ModuleTestBase {
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonNullableBasicTest extends ModuleTestBase {
 
     public static final class JsonNullableData {
         public JsonNullable<String> myString;
@@ -58,7 +61,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
 
     private final ObjectMapper MAPPER = mapperWithModule();
 
-    public void testJsonNullableTypeResolution() throws Exception {
+    @Test
+    void testJsonNullableTypeResolution() {
         // With 2.6, we need to recognize it as ReferenceType
         JavaType t = MAPPER.constructType(JsonNullable.class);
         assertNotNull(t);
@@ -66,14 +70,16 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertTrue(t.isReferenceType());
     }
 
-    public void testDeserAbsent() throws Exception {
+    @Test
+    void testDeserAbsent() throws Exception {
         JsonNullable<?> value = MAPPER.readValue("null",
                 new TypeReference<JsonNullable<String>>() {
                 });
         assertNull(value.get());
     }
 
-    public void testDeserSimpleString() throws Exception {
+    @Test
+    void testDeserSimpleString() throws Exception {
         JsonNullable<?> value = MAPPER.readValue("\"simpleString\"",
                 new TypeReference<JsonNullable<String>>() {
                 });
@@ -81,14 +87,16 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("simpleString", value.get());
     }
 
-    public void testDeserInsideObject() throws Exception {
+    @Test
+    void testDeserInsideObject() throws Exception {
         JsonNullableData data = MAPPER.readValue("{\"myString\":\"simpleString\"}",
                 JsonNullableData.class);
         assertTrue(data.myString.isPresent());
         assertEquals("simpleString", data.myString.get());
     }
 
-    public void testDeserComplexObject() throws Exception {
+    @Test
+    void testDeserComplexObject() throws Exception {
         TypeReference<JsonNullable<JsonNullableData>> type = new TypeReference<JsonNullable<JsonNullableData>>() {
         };
         JsonNullable<JsonNullableData> data = MAPPER.readValue(
@@ -98,7 +106,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("simpleString", data.get().myString.get());
     }
 
-    public void testDeserGeneric() throws Exception {
+    @Test
+    void testDeserGeneric() throws Exception {
         TypeReference<JsonNullable<JsonNullableGenericData<String>>> type = new TypeReference<JsonNullable<JsonNullableGenericData<String>>>() {
         };
         JsonNullable<JsonNullableGenericData<String>> data = MAPPER.readValue(
@@ -108,38 +117,44 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("simpleString", data.get().myData.get());
     }
 
-    public void testSerAbsent() throws Exception {
+    @Test
+    void testSerAbsent() throws Exception {
         String value = MAPPER.writeValueAsString(JsonNullable.undefined());
         assertEquals("null", value);
     }
 
-    public void testSerSimpleString() throws Exception {
+    @Test
+    void testSerSimpleString() throws Exception {
         String value = MAPPER.writeValueAsString(JsonNullable.of("simpleString"));
         assertEquals("\"simpleString\"", value);
     }
 
-    public void testSerInsideObject() throws Exception {
+    @Test
+    void testSerInsideObject() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.of("simpleString");
         String value = MAPPER.writeValueAsString(data);
         assertEquals("{\"myString\":\"simpleString\"}", value);
     }
 
-    public void testSerComplexObject() throws Exception {
+    @Test
+    void testSerComplexObject() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.of("simpleString");
         String value = MAPPER.writeValueAsString(JsonNullable.of(data));
         assertEquals("{\"myString\":\"simpleString\"}", value);
     }
 
-    public void testSerGeneric() throws Exception {
+    @Test
+    void testSerGeneric() throws Exception {
         JsonNullableGenericData<String> data = new JsonNullableGenericData<String>();
         data.myData = JsonNullable.of("simpleString");
         String value = MAPPER.writeValueAsString(JsonNullable.of(data));
         assertEquals("{\"myData\":\"simpleString\"}", value);
     }
 
-    public void testSerOptDefault() throws Exception {
+    @Test
+    void testSerOptDefault() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.undefined();
         String value = mapperWithModule().setSerializationInclusion(
@@ -147,7 +162,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{}", value);
     }
 
-    public void testSerOptNull() throws Exception {
+    @Test
+    void testSerOptNull() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = null;
         String value = mapperWithModule().setSerializationInclusion(
@@ -155,7 +171,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{}", value);
     }
 
-    public void testSerOptNullNulled() throws Exception {
+    @Test
+    void testSerOptNullNulled() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.of(null);
         String value = mapperWithModule().setSerializationInclusion(
@@ -163,7 +180,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{\"myString\":null}", value);
     }
 
-    public void testSerOptAbsent() throws Exception {
+    @Test
+    void testSerOptAbsent() throws Exception {
         final JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.undefined();
 
@@ -183,7 +201,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{}", mapper.writeValueAsString(data));
     }
 
-    public void testSerOptAbsentNull() throws Exception {
+    @Test
+    void testSerOptAbsentNull() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = JsonNullable.of(null);
         String value = mapperWithModule().setSerializationInclusion(
@@ -191,7 +210,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{\"myString\":null}", value);
     }
 
-    public void testSerOptNonEmpty() throws Exception {
+    @Test
+    void testSerOptNonEmpty() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = null;
         String value = mapperWithModule().setSerializationInclusion(
@@ -199,7 +219,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals("{}", value);
     }
 
-    public void testWithTypingEnabled() throws Exception {
+    @Test
+    void testWithTypingEnabled() throws Exception {
         final ObjectMapper objectMapper = mapperWithModule();
         // ENABLE TYPING
         objectMapper
@@ -214,7 +235,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertEquals(myData.myString, deserializedMyData.myString);
     }
 
-    public void testObjectId() throws Exception {
+    @Test
+    void testObjectId() throws Exception {
         final Unit input = new Unit();
         input.link(input);
         String json = MAPPER.writeValueAsString(input);
@@ -226,7 +248,8 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         assertSame(result, base);
     }
 
-    public void testJsonNullableCollection() throws Exception {
+    @Test
+    void testJsonNullableCollection() throws Exception {
 
         TypeReference<List<JsonNullable<String>>> typeReference = new TypeReference<List<JsonNullable<String>>>() {
         };
@@ -242,17 +265,18 @@ public class JsonNullableBasicTest extends ModuleTestBase {
         List<JsonNullable<String>> result = MAPPER.readValue(str, typeReference);
         assertEquals(list.size(), result.size());
         for (int i = 0; i < list.size(); ++i) {
-            assertEquals("Entry #" + i, list.get(i), result.get(i));
+            assertEquals(list.get(i), result.get(i),"Entry #" + i);
         }
     }
 
-    public void testDeserNull() throws Exception {
+    @Test
+    void testDeserNull() throws Exception {
         JsonNullable<?> value = MAPPER.readValue("\"\"", new TypeReference<JsonNullable<Integer>>() {});
         assertFalse(value.isPresent());
     }
 
-    public void testPolymorphic() throws Exception
-    {
+    @Test
+    void testPolymorphic() throws Exception {
         final Container dto = new Container();
         dto.contained = JsonNullable.of((Contained) new ContainedImpl());
 

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableInclusionTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableInclusionTest.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class JsonNullableInclusionTest extends ModuleTestBase
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonNullableInclusionTest extends ModuleTestBase
 {
     @JsonAutoDetect(fieldVisibility=Visibility.ANY)
     public static final class JsonNullableData {
@@ -53,8 +56,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
 
     private final ObjectMapper MAPPER = mapperWithModule();
 
-    public void testSerOptNonEmpty() throws Exception
-    {
+    @Test
+    void testSerOptNonEmpty() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = null;
         String value = mapperWithModule().setSerializationInclusion(
@@ -62,8 +65,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
-    public void testSerOptNonDefault() throws Exception
-    {
+    @Test
+    void testSerOptNonDefault() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = null;
         String value = mapperWithModule().setSerializationInclusion(
@@ -71,8 +74,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
-    public void testSerOptNonAbsent() throws Exception
-    {
+    @Test
+    void testSerOptNonAbsent() throws Exception {
         JsonNullableData data = new JsonNullableData();
         data.myString = null;
         String value = mapperWithModule().setSerializationInclusion(
@@ -80,8 +83,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
-    public void testExcludeEmptyStringViaJsonNullable() throws Exception
-    {
+    @Test
+    void testExcludeEmptyStringViaJsonNullable() throws Exception {
         String json = MAPPER.writeValueAsString(new JsonNullableNonEmptyStringBean("x"));
         assertEquals("{\"value\":\"x\"}", json);
         json = MAPPER.writeValueAsString(new JsonNullableNonEmptyStringBean(null));
@@ -90,8 +93,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
         assertEquals("{}", json);
     }
 
-    public void testSerPropInclusionAlways() throws Exception
-    {
+    @Test
+    void testSerPropInclusionAlways() throws Exception {
         JsonInclude.Value incl =
                 JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS);
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(incl);
@@ -99,8 +102,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(JsonNullableGenericData.construct(Boolean.TRUE)));
     }
 
-    public void testSerPropInclusionNonNull() throws Exception
-    {
+    @Test
+    void testSerPropInclusionNonNull() throws Exception {
         JsonInclude.Value incl =
                 JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_NULL);
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(incl);
@@ -108,8 +111,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(JsonNullableGenericData.construct(Boolean.TRUE)));
     }
 
-    public void testSerPropInclusionNonAbsent() throws Exception
-    {
+    @Test
+    void testSerPropInclusionNonAbsent() throws Exception {
         JsonInclude.Value incl =
                 JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_ABSENT);
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(incl);
@@ -117,8 +120,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(JsonNullableGenericData.construct(Boolean.TRUE)));
     }
 
-    public void testSerPropInclusionNonEmpty() throws Exception
-    {
+    @Test
+    void testSerPropInclusionNonEmpty() throws Exception {
         JsonInclude.Value incl =
                 JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.NON_EMPTY);
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(incl);
@@ -126,8 +129,8 @@ public class JsonNullableInclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(JsonNullableGenericData.construct(Boolean.TRUE)));
     }
 
-    public void testMapElementInclusion() throws Exception
-    {
+    @Test
+    void testMapElementInclusion() throws Exception {
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(
                 JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_ABSENT));
         // first: Absent entry/-ies should NOT be included

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
@@ -4,35 +4,35 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public final class JsonNullableSimpleTest {
+final class JsonNullableSimpleTest {
 
     private ObjectMapper mapper;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         mapper = new ObjectMapper();
         mapper.registerModule(new JsonNullableModule());
     }
 
     @Test
-    public void get() {
+    void get() {
         JsonNullable<String> test = JsonNullable.of("hello");
         assertTrue(test.isPresent());
         assertEquals("hello", test.get());
     }
 
     @Test
-    public void getMissing() {
+    void getMissing() {
         JsonNullable<String> test = JsonNullable.undefined();
         assertFalse(test.isPresent());
         try {
@@ -44,45 +44,45 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void orElse() {
+    void orElse() {
         JsonNullable<String> test = JsonNullable.of("hello");
         assertTrue(test.isPresent());
         assertEquals("hello", test.orElse("world"));
     }
 
     @Test
-    public void orElseMissing() {
+    void orElseMissing() {
         JsonNullable<String> test = JsonNullable.undefined();
         assertFalse(test.isPresent());
         assertEquals("world", test.orElse("world"));
     }
 
     @Test
-    public void ifPresentWithValueNotPresent() {
+    void ifPresentWithValueNotPresent() {
         JsonNullable<String> test = JsonNullable.undefined();
-        test.ifPresent(string -> {
+        assertDoesNotThrow(() -> test.ifPresent(string -> {
             throw new RuntimeException();
-        });
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void ifPresentWithNullValuePresent() {
-        JsonNullable<String> test = JsonNullable.of(null);
-        test.ifPresent(string -> {
-            throw new RuntimeException();
-        });
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void ifPresentWithNonNullValuePresent() {
-        JsonNullable<String> test = JsonNullable.of("test");
-        test.ifPresent(string -> {
-            throw new RuntimeException();
-        });
+        }));
     }
 
     @Test
-    public void serializeNonBeanProperty() throws JsonProcessingException {
+    void ifPresentWithNullValuePresent() {
+        JsonNullable<String> test = JsonNullable.of(null);
+        assertThrows(RuntimeException.class, () -> test.ifPresent(string -> {
+            throw new RuntimeException();
+        }));
+    }
+
+    @Test
+    void ifPresentWithNonNullValuePresent() {
+        JsonNullable<String> test = JsonNullable.of("test");
+        assertThrows(RuntimeException.class, () -> test.ifPresent(string -> {
+            throw new RuntimeException();
+        }));
+    }
+
+    @Test
+    void serializeNonBeanProperty() throws JsonProcessingException {
         assertEquals("null", mapper.writeValueAsString(JsonNullable.of(null)));
         assertEquals("\"foo\"", mapper.writeValueAsString(JsonNullable.of("foo")));
         // TODO: Serialize non bean JsonNullable.undefined to empty string
@@ -91,7 +91,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void serializeAlways() throws JsonProcessingException {
+    void serializeAlways() throws JsonProcessingException {
         assertEquals("{}", mapper.writeValueAsString(new Pet().name(JsonNullable.<String>undefined())));
         assertEquals("{\"name\":null}", mapper.writeValueAsString(new Pet().name(null)));
         assertEquals("{\"name\":null}", mapper.writeValueAsString(new Pet().name(JsonNullable.<String>of(null))));
@@ -99,7 +99,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void serializeNonNull() throws JsonProcessingException {
+    void serializeNonNull() throws JsonProcessingException {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         assertEquals("{}", mapper.writeValueAsString(new Pet().name(JsonNullable.<String>undefined())));
         assertEquals("{}", mapper.writeValueAsString(new Pet().name(null)));
@@ -108,7 +108,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void serializeNonAbsent() throws JsonProcessingException {
+    void serializeNonAbsent() throws JsonProcessingException {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         assertEquals("{}", mapper.writeValueAsString(new Pet().name(JsonNullable.<String>undefined())));
         assertEquals("{}", mapper.writeValueAsString(new Pet().name(null)));
@@ -117,7 +117,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void serializeCollection() throws JsonProcessingException {
+    void serializeCollection() throws JsonProcessingException {
         assertEquals("[\"foo\",null,null,null]", mapper.writeValueAsString(Arrays.asList(
                 JsonNullable.of("foo"),
                 JsonNullable.of(null),
@@ -127,7 +127,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void deserializeStringMembers() throws IOException {
+    void deserializeStringMembers() throws IOException {
         testReadPetName(JsonNullable.of("Rex"), "{\"name\":\"Rex\"}");
         testReadPetName(JsonNullable.<String>of(null), "{\"name\":null}");
         testReadPetName(JsonNullable.<String>of(""), "{\"name\":\"\"}");
@@ -136,7 +136,7 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void deserializeNonStringMembers() throws IOException {
+    void deserializeNonStringMembers() throws IOException {
         testReadPetAge(JsonNullable.of(Integer.valueOf(15)), "{\"age\":\"15\"}");
         testReadPetAge(JsonNullable.<Integer>of(null), "{\"age\":null}");
         testReadPetAge(JsonNullable.<Integer>undefined(), "{\"age\":\"\"}");
@@ -145,23 +145,31 @@ public final class JsonNullableSimpleTest {
     }
 
     @Test
-    public void deserializeStringNonBeanMembers() throws IOException {
-        assertEquals(JsonNullable.of(null), mapper.readValue("null", new TypeReference<JsonNullable<String>>() {}));
-        assertEquals(JsonNullable.of("42"), mapper.readValue("\"42\"", new TypeReference<JsonNullable<String>>() {}));
-        assertEquals(JsonNullable.of(""), mapper.readValue("\"\"", new TypeReference<JsonNullable<String>>() {}));
-        assertEquals(JsonNullable.of("   "), mapper.readValue("\"   \"", new TypeReference<JsonNullable<String>>() {}));
+    void deserializeStringNonBeanMembers() throws IOException {
+        assertEquals(JsonNullable.of(null), mapper.readValue("null", new TypeReference<JsonNullable<String>>() {
+        }));
+        assertEquals(JsonNullable.of("42"), mapper.readValue("\"42\"", new TypeReference<JsonNullable<String>>() {
+        }));
+        assertEquals(JsonNullable.of(""), mapper.readValue("\"\"", new TypeReference<JsonNullable<String>>() {
+        }));
+        assertEquals(JsonNullable.of("   "), mapper.readValue("\"   \"", new TypeReference<JsonNullable<String>>() {
+        }));
     }
 
     @Test
-    public void deserializeNonStringNonBeanMembers() throws IOException {
-        assertEquals(JsonNullable.of(null), mapper.readValue("\"null\"", new TypeReference<JsonNullable<Integer>>() {}));
-        assertEquals(JsonNullable.of(42), mapper.readValue("\"42\"", new TypeReference<JsonNullable<Integer>>() {}));
-        assertEquals(JsonNullable.undefined(), mapper.readValue("\"\"", new TypeReference<JsonNullable<Integer>>() {}));
-        assertEquals(JsonNullable.undefined(), mapper.readValue("\"  \"", new TypeReference<JsonNullable<Integer>>() {}));
+    void deserializeNonStringNonBeanMembers() throws IOException {
+        assertEquals(JsonNullable.of(null), mapper.readValue("\"null\"", new TypeReference<JsonNullable<Integer>>() {
+        }));
+        assertEquals(JsonNullable.of(42), mapper.readValue("\"42\"", new TypeReference<JsonNullable<Integer>>() {
+        }));
+        assertEquals(JsonNullable.undefined(), mapper.readValue("\"\"", new TypeReference<JsonNullable<Integer>>() {
+        }));
+        assertEquals(JsonNullable.undefined(), mapper.readValue("\"  \"", new TypeReference<JsonNullable<Integer>>() {
+        }));
     }
 
     @Test
-    public void deserializeCollection() throws IOException {
+    void deserializeCollection() throws IOException {
         List<JsonNullable<String>> values = mapper.readValue("[\"foo\", null]",
                 new TypeReference<List<JsonNullable<String>>>() {
                 });

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableTest.java
@@ -14,11 +14,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class JsonNullableTest extends ModuleTestBase
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JsonNullableTest extends ModuleTestBase
 {
     private static final TypeReference<JsonNullable<String>> JSON_NULLABLE_STRING_TYPE = new TypeReference<JsonNullable<String>>() {};
     private static final TypeReference<JsonNullable<TestBean>> JSON_NULLABLE_BEAN_TYPE = new TypeReference<JsonNullable<TestBean>>() {};
@@ -123,10 +129,8 @@ public class JsonNullableTest extends ModuleTestBase
 
     private ObjectMapper MAPPER;
 
-    @Override
-    protected void setUp() throws Exception
-    {
-        super.setUp();
+    @BeforeAll
+    void setUp() {
         MAPPER = mapperWithModule();
     }
 
@@ -136,39 +140,39 @@ public class JsonNullableTest extends ModuleTestBase
     /**********************************************************
      */
 
-    public void testStringAbsent() throws Exception
-    {
+    @Test
+    void testStringAbsent() throws Exception {
         assertNull(roundtrip(JsonNullable.<String>undefined(), JSON_NULLABLE_STRING_TYPE).get());
     }
-    public void testStringNull() throws Exception
-    {
+    @Test
+    void testStringNull() throws Exception {
         assertNull(roundtrip(JsonNullable.<String>of(null), JSON_NULLABLE_STRING_TYPE).get());
     }
 
-    public void testStringPresent() throws Exception
-    {
+    @Test
+    void testStringPresent() throws Exception {
         assertEquals("test", roundtrip(JsonNullable.of("test"), JSON_NULLABLE_STRING_TYPE).get());
     }
 
-    public void testBeanAdsent() throws Exception
-    {
+    @Test
+    void testBeanAdsent() throws Exception {
         assertNull(roundtrip(JsonNullable.<TestBean>undefined(), JSON_NULLABLE_BEAN_TYPE).get());
     }
 
-    public void testBeanNull() throws Exception
-    {
+    @Test
+    void testBeanNull() throws Exception {
         assertNull(roundtrip(JsonNullable.<TestBean>of(null), JSON_NULLABLE_BEAN_TYPE).get());
     }
 
-    public void testBeanPresent() throws Exception
-    {
+    @Test
+    void testBeanPresent() throws Exception {
         final TestBean bean = new TestBean(Integer.MAX_VALUE, "woopwoopwoopwoopwoop");
         assertEquals(bean, roundtrip(JsonNullable.of(bean), JSON_NULLABLE_BEAN_TYPE).get());
     }
 
     // [issue#4]
-    public void testBeanWithCreator() throws Exception
-    {
+    @Test
+    void testBeanWithCreator() throws Exception {
         final Issue4Entity emptyEntity = new Issue4Entity(JsonNullable.<String>of(null));
         final String json = MAPPER.writeValueAsString(emptyEntity);
 
@@ -179,16 +183,16 @@ public class JsonNullableTest extends ModuleTestBase
     }
 
     // [issue#4]
-    public void testJsonNullableStringInBean() throws Exception
-    {
+    @Test
+    void testJsonNullableStringInBean() throws Exception {
         JsonNullableStringBean bean = MAPPER.readValue("{\"value\":\"xyz\"}", JsonNullableStringBean.class);
         assertNotNull(bean.value);
         assertEquals("xyz", bean.value.get());
     }
 
     // To support [datatype-jdk8#8]
-    public void testExcludeIfJsonNullableAbsent() throws Exception
-    {
+    @Test
+    void testExcludeIfJsonNullableAbsent() throws Exception {
         ObjectMapper mapper = mapperWithModule()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
         assertEquals(aposToQuotes("{'value':'foo'}"),
@@ -206,16 +210,16 @@ public class JsonNullableTest extends ModuleTestBase
                 mapper.writeValueAsString(new JsonNullableStringBean(null)));
     }
 
-    public void testWithCustomDeserializer() throws Exception
-    {
+    @Test
+    void testWithCustomDeserializer() throws Exception {
         CaseChangingStringWrapper w = MAPPER.readValue(aposToQuotes("{'value':'FoobaR'}"),
                 CaseChangingStringWrapper.class);
         assertEquals("foobar", w.value.get());
     }
 
     // [modules-java8#36]
-    public void testWithCustomDeserializerIfJsonNullableAbsent() throws Exception
-    {
+    @Test
+    void testWithCustomDeserializerIfJsonNullableAbsent() throws Exception {
         // 10-Aug-2017, tatu: Actually this is not true: missing value does not trigger
         //    specific handling
         /*
@@ -227,15 +231,15 @@ public class JsonNullableTest extends ModuleTestBase
                 CaseChangingStringWrapper.class).value);
     }
 
-    public void testCustomSerializer() throws Exception
-    {
+    @Test
+    void testCustomSerializer() throws Exception {
         final String VALUE = "fooBAR";
         String json = MAPPER.writeValueAsString(new CaseChangingStringWrapper(VALUE));
         assertEquals(json, aposToQuotes("{'value':'FOOBAR'}"));
     }
 
-    public void testCustomSerializerIfJsonNullableAbsent() throws Exception
-    {
+    @Test
+    void testCustomSerializerIfJsonNullableAbsent() throws Exception {
         ObjectMapper mapper = mapperWithModule()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
         assertEquals(aposToQuotes("{'value':'FOO'}"),
@@ -258,8 +262,8 @@ public class JsonNullableTest extends ModuleTestBase
     }
 
     // [modules-java8#33]: Verify against regression...
-    public void testOtherRefSerializers() throws Exception
-    {
+    @Test
+    void testOtherRefSerializers() throws Exception {
         String json = MAPPER.writeValueAsString(new AtomicReference<String>("foo"));
         assertEquals(quote("foo"), json);
     }
@@ -270,8 +274,7 @@ public class JsonNullableTest extends ModuleTestBase
     /**********************************************************
      */
 
-    private <T> JsonNullable<T> roundtrip(JsonNullable<T> obj, TypeReference<JsonNullable<T>> type) throws IOException
-    {
+    private <T> JsonNullable<T> roundtrip(JsonNullable<T> obj, TypeReference<JsonNullable<T>> type) throws IOException {
         String bytes = MAPPER.writeValueAsString(obj);
         return MAPPER.readValue(bytes, type);
     }

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableUnwrappedTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableUnwrappedTest.java
@@ -7,13 +7,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 // TODO: Make JsonNulllable work with JsonUnwrapped
-@Ignore("JsonNullable currently doesnt work with JsonUnwrapped")
-public class JsonNullableUnwrappedTest extends ModuleTestBase
+@Disabled("JsonNullable currently doesnt work with JsonUnwrapped")
+class JsonNullableUnwrappedTest extends ModuleTestBase
 {
     static class Child {
         public String name = "Bob";
@@ -48,8 +51,8 @@ public class JsonNullableUnwrappedTest extends ModuleTestBase
         public String name;
     }
 
-    public void testUntypedWithJsonNullablesNotNulls() throws Exception
-    {
+    @Test
+    void testUntypedWithJsonNullablesNotNulls() throws Exception {
         final ObjectMapper mapper = mapperWithModule();
         String jsonExp = aposToQuotes("{'XX.name':'Bob'}");
         String jsonAct = mapper.writeValueAsString(new JsonNullableParent());
@@ -57,7 +60,8 @@ public class JsonNullableUnwrappedTest extends ModuleTestBase
     }
 
     // for [datatype-jdk8#20]
-    public void testShouldSerializeUnwrappedJsonNullable() throws Exception {
+    @Test
+    void testShouldSerializeUnwrappedJsonNullable() throws Exception {
         final ObjectMapper mapper = mapperWithModule();
 
         assertEquals("{\"id\":\"foo\"}",
@@ -65,7 +69,8 @@ public class JsonNullableUnwrappedTest extends ModuleTestBase
     }
 
     // for [datatype-jdk8#26]
-    public void testPropogatePrefixToSchema() throws Exception {
+    @Test
+    void testPropogatePrefixToSchema() throws Exception {
         final ObjectMapper mapper = mapperWithModule();
 
         final AtomicReference<String> propertyName = new AtomicReference<String>();

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableValueExtractorTest.java
@@ -1,8 +1,9 @@
 package org.openapitools.jackson.nullable;
 
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import javax.validation.*;
 import javax.validation.constraints.Max;
@@ -13,15 +14,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
-public class JsonNullableValueExtractorTest {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JsonNullableValueExtractorTest {
     private Validator validator;
 
-    @Before
-    public void setUp() {
+    @BeforeAll
+    void setUp() {
         try (ValidatorFactory factory = Validation.byDefaultProvider()
                 .configure()
                 .messageInterpolator(new ParameterMessageInterpolator())
@@ -31,7 +32,7 @@ public class JsonNullableValueExtractorTest {
     }
 
     @Test
-    public void testUnwrap() {
+    void testUnwrap() {
         final UnitIssue2 unitIssue2 = new UnitIssue2();
         unitIssue2.setRestrictedString("a >15 character long string");
         unitIssue2.setNullableRestrictedString("a >15 character long string");
@@ -44,14 +45,14 @@ public class JsonNullableValueExtractorTest {
     }
 
     @Test
-    public void testValidationIsNotApplied_whenValueIsUndefined() {
+    void testValidationIsNotApplied_whenValueIsUndefined() {
         UnitIssue3 unitIssue = new UnitIssue3();
         Set<ConstraintViolation<UnitIssue3>> violations = validator.validate(unitIssue);
         assertEquals(0, violations.size());
     }
 
     @Test
-    public void testValidationIsAppliedOnDefinedValue_whenNullValueExtracted() {
+    void testValidationIsAppliedOnDefinedValue_whenNullValueExtracted() {
         UnitIssue3 unitIssue = new UnitIssue3();
         unitIssue.setNotNullString(null);
         Set<ConstraintViolation<UnitIssue3>> violations = validator.validate(unitIssue);
@@ -59,7 +60,7 @@ public class JsonNullableValueExtractorTest {
     }
     
     @Test
-    public void testCollection() {
+    void testCollection() {
         Car aCar = new Car();
 
         // test for java.util.List

--- a/src/test/java/org/openapitools/jackson/nullable/ModuleTestBase.java
+++ b/src/test/java/org/openapitools/jackson/nullable/ModuleTestBase.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Arrays;
 
-public abstract class ModuleTestBase extends junit.framework.TestCase
+import static org.junit.jupiter.api.Assertions.fail;
+
+abstract class ModuleTestBase
 {
     /*
     /**********************************************************************

--- a/src/test/java/org/openapitools/jackson/nullable/PolymorphicJsonNullableTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/PolymorphicJsonNullableTest.java
@@ -3,9 +3,11 @@ package org.openapitools.jackson.nullable;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
-public class PolymorphicJsonNullableTest extends ModuleTestBase
-{
+import static org.junit.jupiter.api.Assertions.*;
+
+class PolymorphicJsonNullableTest extends ModuleTestBase {
     // For [datatype-jdk8#14]
     public static class Container {
         public JsonNullable<Contained> contained;
@@ -22,8 +24,8 @@ public class PolymorphicJsonNullableTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
 
     // [datatype-jdk8#14]
-    public void testPolymorphic14() throws Exception
-    {
+    @Test
+    void testPolymorphic14() throws Exception {
         final Container dto = new Container();
         dto.contained = JsonNullable.<Contained>of(new ContainedImpl());
 

--- a/src/test/java/org/openapitools/jackson/nullable/TestJsonNullableWithPolymorphic.java
+++ b/src/test/java/org/openapitools/jackson/nullable/TestJsonNullableWithPolymorphic.java
@@ -6,12 +6,15 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class TestJsonNullableWithPolymorphic extends ModuleTestBase
-{
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class TestJsonNullableWithPolymorphic extends ModuleTestBase {
     static class ContainerA {
         @JsonProperty
         private JsonNullable<String> name = JsonNullable.undefined();
@@ -69,7 +72,8 @@ public class TestJsonNullableWithPolymorphic extends ModuleTestBase
 
     final ObjectMapper MAPPER = mapperWithModule();
 
-    public void testJsonNullableMapsFoo() throws Exception {
+    @Test
+    void testJsonNullableMapsFoo() throws Exception {
 
         Map<String, Object> foo = new LinkedHashMap<String, Object>();
         Map<String, Object> loop = new LinkedHashMap<String, Object>();
@@ -82,7 +86,8 @@ public class TestJsonNullableWithPolymorphic extends ModuleTestBase
         _test(MAPPER, foo);
     }
 
-    public void testJsonNullableMapsBar() throws Exception {
+    @Test
+    void testJsonNullableMapsBar() throws Exception {
 
         Map<String, Object> bar = new LinkedHashMap<String, Object>();
         Map<String, Object> loop = new LinkedHashMap<String, Object>();
@@ -95,7 +100,8 @@ public class TestJsonNullableWithPolymorphic extends ModuleTestBase
         _test(MAPPER, bar);
     }
 
-    public void testJsonNullableMapsBaz() throws Exception {
+    @Test
+    void testJsonNullableMapsBaz() throws Exception {
         Map<String, Object> baz = new LinkedHashMap<String, Object>();
         Map<String, Object> loop = new LinkedHashMap<String, Object>();
         loop.put("type", "Baz");
@@ -107,8 +113,8 @@ public class TestJsonNullableWithPolymorphic extends ModuleTestBase
         _test(MAPPER, baz);
     }
 
-    public void testJsonNullableWithTypeAnnotation13() throws Exception
-    {
+    @Test
+    void testJsonNullableWithTypeAnnotation13() throws Exception {
         AbstractJsonNullable result = MAPPER.readValue("{\"value\" : 5}",
                 AbstractJsonNullable.class);
         assertNotNull(result);


### PR DESCRIPTION
- Updated to JUnit 5. The version is still managed by the parent.
- Tests no longer extend TestCase
- Annotated test methods with `@Test`.
- Made classes and test methods package-private, as it is recommended.
- Add GitHub Action to run tests automatically
  - This excludes master, since the maven_release.yaml workflow already tests master.