### PR TITLE
Ignore Hibernate Validator updates until Java 17+ is used for builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Ignore semver-major updates until Java 17+ is used for builds.
+      - dependency-name: "org.hibernate.validator:hibernate-validator"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
An alternative to this would be to use a Dependabot action on the [existing PR](https://github.com/OpenAPITools/jackson-databind-nullable/pull/81) to ignore this dependency until it is manually updated.

From the PR description.

> `@dependabot ignore this dependency` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)

I don't have a strong preference either way. I assume I don't have access to run the dependabot commands though.