### PR TITLE
Ignore semver-major Mockito and JUnit updates until Java 17+ is used for builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       # Ignore semver-major updates until Java 17+ is used for builds.
       - dependency-name: "org.hibernate.validator:hibernate-validator"
         update-types: ["version-update:semver-major"]
+      # Ignore semver-major updates until Java 17+ is used for builds.
+      - dependency-name: "org.mockito:mockito-core"
+        update-types: ["version-update:semver-major"]
+      # Ignore semver-major updates until Java 17+ is used for builds.
+      - dependency-name: "org.junit:junit-bom"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Same as the Hibernate Validator change. Ignore semver-major updates for some libraries that have transitioned to Java 17.