### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 This module provides a `JsonNullable` wrapper class and a Jackson module to serialize/deserialize it.
 The `JsonNullable` wrapper shall be used to wrap Java bean fields for which it is important to distinguish between an explicit `"null"` and the field not being present.
-A typical usage is when implementing [Json Merge Patch](https://tools.ietf.org/html/rfc7386) where an explicit `"null"`has the meaning "set this field to null / remove this field" whereas a non-present field has the meaning "don't change the value of this field".
+A typical usage is when implementing [Json Merge Patch](https://tools.ietf.org/html/rfc7386) where an explicit `"null"` has the meaning "set this field to null / remove this field" whereas a non-present field has the meaning "don't change the value of this field".
 
 The module comes with an integrated `ValueExtractor` that automatically unwraps the contained value of the `JsonNullable` if used together with javax.validation Bean validation (JSR 380). 
 
-Note : a lot of people use `Optional` to bring this behavior.
+Note: a lot of people use `Optional` to bring this behavior.
 Although it kinda works, it's not a good idea because:
 * Beans shouldn't have `Optional` fields.
   `Optional` was designed to be used only as method return value.
@@ -84,7 +84,7 @@ The `ValueExtractor` is registered automatically via Java Service loader mechani
 Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 Pet myPet = new Pet().name(JsonNullable.of("My Pet's really long name"));
 Set<ConstraintViolation<Pet>> validationResult = validator.validate(myPet);
-assertTrue(1, validationResult.size());
+assertEquals(1, validationResult.size());
 ```
 
 ## Limitations

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
@@ -209,7 +209,7 @@ public class JsonNullable<T> implements Serializable {
     /**
      * If a value is present, returns a JsonNullable describing the result of
      * applying the given mapping function to the value, otherwise returns an
-     * undeined JsonNullable.
+     * undefined JsonNullable.
      *
      * @param <U> the type of the value returned from the mapping function
      * @param mapper the mapping function to apply to a value, if present

--- a/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 // TODO: fix JsonNullable in constructor annotated by JsonCreator
-@Disabled("JsonNullable in a constructor is dederialized to JsonNullable[null] instead of JsonNullable.undefined")
+@Disabled("JsonNullable in a constructor is deserialized to JsonNullable[null] instead of JsonNullable.undefined")
 class CreatorTest extends ModuleTestBase
 {
     static class CreatorWithJsonNullableStrings

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableUnwrappedTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableUnwrappedTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// TODO: Make JsonNulllable work with JsonUnwrapped
+// TODO: Make JsonNullable work with JsonUnwrapped
 @Disabled("JsonNullable currently doesnt work with JsonUnwrapped")
 class JsonNullableUnwrappedTest extends ModuleTestBase
 {

--- a/src/test/java/org/openapitools/jackson/nullable/StreamingApiTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/StreamingApiTest.java
@@ -658,7 +658,7 @@ public class StreamingApiTest {
     }
 
     //
-    // These static methods form a two-way coorespondance between JsonNullable<String> and
+    // These static methods form a two-way correspondence between JsonNullable<String> and
     // Optional<Optional<String>>
     //
     static Optional<Optional<String>> nullableToOptional(JsonNullable<String> value) {


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help