### PR TITLE
Change the maven compile execution for Java 8 to override the default compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,8 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>compile-java-8</id>
+                        <!-- Named specifically to override the default compile execution -->
+                        <id>default-compile</id>
                         <goals>
                             <goal>compile</goal>
                         </goals>


### PR DESCRIPTION
This avoids performing a default-compile, compile-java-8, and compile-java-9 execution. Only default-compile and compile-java-9 is executed.

`compile-java-8` overwrites the output of `default-compile` right now, so there's no change in the end result of the class files with this PR.

Before this change
```
[INFO] --- compiler:3.14.1:compile (default-compile) @ jackson-databind-nullable ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 14 source files with javac [debug:lines,source,vars deprecation target 1.8] to target/classes
[WARNING] bootstrap class path not set in conjunction with -source 8
[INFO] 
[INFO] --- compiler:3.14.1:compile (compile-java-8) @ jackson-databind-nullable ---
[INFO] Recompiling the module because of added or removed source files.
[INFO] Compiling 14 source files with javac [debug:lines,source,vars deprecation release 8] to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (compile-java-9) @ jackson-databind-nullable ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 1 source file with javac [debug:lines,source,vars deprecation release 9 module-path] to target/classes/META-INF/versions/9
```

After this change
```
[INFO] --- compiler:3.14.1:compile (default-compile) @ jackson-databind-nullable ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 14 source files with javac [debug:lines,source,vars deprecation release 8] to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (compile-java-9) @ jackson-databind-nullable ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 1 source file with javac [debug:lines,source,vars deprecation release 9 module-path] to target/classes/META-INF/versions/9
```
