### PR TITLE
fix: add mapBlankStringToNull option to JsonNullableModule

### DIFF
--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializer.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializer.java
@@ -19,6 +19,7 @@ public class JsonNullableDeserializer extends ReferenceTypeDeserializer<JsonNull
     private static final long serialVersionUID = 1L;
 
     private boolean isStringDeserializer = false;
+    private final boolean mapBlankStringToNull;
 
     /*
     /**********************************************************
@@ -26,8 +27,10 @@ public class JsonNullableDeserializer extends ReferenceTypeDeserializer<JsonNull
     /**********************************************************
      */
     public JsonNullableDeserializer(JavaType fullType, ValueInstantiator inst,
-                                    TypeDeserializer typeDeser, JsonDeserializer<?> deser) {
+                                    TypeDeserializer typeDeser, JsonDeserializer<?> deser,
+                                    boolean mapBlankStringToNull) {
         super(fullType, inst, typeDeser, deser);
+        this.mapBlankStringToNull = mapBlankStringToNull;
         if (fullType instanceof ReferenceType && ((ReferenceType) fullType).getReferencedType() != null) {
             this.isStringDeserializer = ((ReferenceType) fullType).getReferencedType().isTypeOrSubTypeOf(String.class);
         }
@@ -45,7 +48,7 @@ public class JsonNullableDeserializer extends ReferenceTypeDeserializer<JsonNull
         if (t == JsonToken.VALUE_STRING && !isStringDeserializer) {
             String str = p.getText().trim();
             if (str.isEmpty()) {
-                return JsonNullable.undefined();
+                return mapBlankStringToNull ? JsonNullable.of(null) : JsonNullable.undefined();
             }
         }
         return super.deserialize(p, ctxt);
@@ -54,7 +57,7 @@ public class JsonNullableDeserializer extends ReferenceTypeDeserializer<JsonNull
     @Override
     public JsonNullableDeserializer withResolved(TypeDeserializer typeDeser, JsonDeserializer<?> valueDeser) {
         return new JsonNullableDeserializer(_fullType, _valueInstantiator,
-                typeDeser, valueDeser);
+                typeDeser, valueDeser, mapBlankStringToNull);
     }
 
     @Override

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializers.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableDeserializers.java
@@ -9,10 +9,18 @@ import com.fasterxml.jackson.databind.type.ReferenceType;
 
 public class JsonNullableDeserializers extends Deserializers.Base {
 
+    private final boolean mapBlankStringToNull;
+
+    public JsonNullableDeserializers(boolean mapBlankStringToNull) {
+        this.mapBlankStringToNull = mapBlankStringToNull;
+    }
+
     @Override
     public JsonDeserializer<?> findReferenceDeserializer(ReferenceType refType,
                                                          DeserializationConfig config, BeanDescription beanDesc,
                                                          TypeDeserializer contentTypeDeserializer, JsonDeserializer<?> contentDeserializer) {
-        return (refType.hasRawClass(JsonNullable.class)) ? new JsonNullableDeserializer(refType, null, contentTypeDeserializer,contentDeserializer) : null;
+        return (refType.hasRawClass(JsonNullable.class))
+            ? new JsonNullableDeserializer(refType, null, contentTypeDeserializer, contentDeserializer, mapBlankStringToNull)
+            : null;
     }
 }

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableModule.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableModule.java
@@ -7,11 +7,27 @@ import com.fasterxml.jackson.databind.Module;
 public class JsonNullableModule extends Module {
 
     private final String NAME = "JsonNullableModule";
+    private boolean mapBlankStringToNull = false;
+
+    /**
+     * Configures whether blank strings (e.g. {@code ""}, {@code "  "}) deserialized into
+     * non-String {@code JsonNullable} fields are mapped to {@code JsonNullable.of(null)}
+     * instead of {@code JsonNullable.undefined()}.
+     *
+     * <p>This is relevant for PATCH semantics: a blank string sent by a client expresses
+     * explicit intent to clear a value, which {@code undefined()} silently swallows.
+     *
+     * <p>Default is {@code false} for backwards compatibility.
+     */
+    public JsonNullableModule mapBlankStringToNull(boolean state) {
+        this.mapBlankStringToNull = state;
+        return this;
+    }
 
     @Override
     public void setupModule(SetupContext context) {
         context.addSerializers(new JsonNullableSerializers());
-        context.addDeserializers(new JsonNullableDeserializers());
+        context.addDeserializers(new JsonNullableDeserializers(mapBlankStringToNull));
         // Modify type info for JsonNullable
         context.addTypeModifier(new JsonNullableTypeModifier());
         context.addBeanSerializerModifier(new JsonNullableBeanSerializerModifier());

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonNullWithEmptyTest  extends ModuleTestBase
 {
     private final ObjectMapper MAPPER = mapperWithModule();
+    private final ObjectMapper MAPPER_BLANK_TO_NULL = mapperWithModule(new JsonNullableModule().mapBlankStringToNull(true));
 
     static class BooleanBean {
         public JsonNullable<Boolean> value;
@@ -19,6 +22,8 @@ class JsonNullWithEmptyTest  extends ModuleTestBase
             value = JsonNullable.of(b);
         }
     }
+
+    // default behavior (mapBlankStringToNull = false)
 
     @Test
     void testJsonNullableFromEmpty() throws Exception {
@@ -37,4 +42,27 @@ class JsonNullWithEmptyTest  extends ModuleTestBase
         assertFalse(b.value.isPresent());
     }
 
+    // mapBlankStringToNull = true
+
+    @Test
+    void testJsonNullableFromEmptyWithMapBlankStringToNull() throws Exception {
+        JsonNullable<?> value = MAPPER_BLANK_TO_NULL.readValue(quote(""), new TypeReference<JsonNullable<Integer>>() {});
+        assertTrue(value.isPresent());
+        assertNull(value.get());
+    }
+
+    @Test
+    void testJsonNullableFromBlankWithMapBlankStringToNull() throws Exception {
+        JsonNullable<?> value = MAPPER_BLANK_TO_NULL.readValue(quote("   "), new TypeReference<JsonNullable<Integer>>() {});
+        assertTrue(value.isPresent());
+        assertNull(value.get());
+    }
+
+    @Test
+    void testBooleanWithEmptyWithMapBlankStringToNull() throws Exception {
+        BooleanBean b = MAPPER_BLANK_TO_NULL.readValue(aposToQuotes("{'value':''}"), BooleanBean.class);
+        assertNotNull(b.value);
+        assertTrue(b.value.isPresent());
+        assertNull(b.value.get());
+    }
 }

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
@@ -60,6 +60,7 @@ class JsonNullableBasicTest extends ModuleTestBase {
      */
 
     private final ObjectMapper MAPPER = mapperWithModule();
+    private final ObjectMapper MAPPER_BLANK_TO_NULL = mapperWithModule(new JsonNullableModule().mapBlankStringToNull(true));
 
     @Test
     void testJsonNullableTypeResolution() {
@@ -270,9 +271,16 @@ class JsonNullableBasicTest extends ModuleTestBase {
     }
 
     @Test
-    void testDeserNull() throws Exception {
+    void testDeserEmptyStringForNonStringType() throws Exception {
         JsonNullable<?> value = MAPPER.readValue("\"\"", new TypeReference<JsonNullable<Integer>>() {});
         assertFalse(value.isPresent());
+    }
+
+    @Test
+    void testDeserEmptyStringForNonStringTypeWithMapBlankStringToNull() throws Exception {
+        JsonNullable<?> value = MAPPER_BLANK_TO_NULL.readValue("\"\"", new TypeReference<JsonNullable<Integer>>() {});
+        assertTrue(value.isPresent());
+        assertNull(value.get());
     }
 
     @Test

--- a/src/test/java/org/openapitools/jackson/nullable/ModuleTestBase.java
+++ b/src/test/java/org/openapitools/jackson/nullable/ModuleTestBase.java
@@ -21,6 +21,13 @@ abstract class ModuleTestBase
         return mapper;
     }
 
+    protected ObjectMapper mapperWithModule(JsonNullableModule module)
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(module);
+        return mapper;
+    }
+
     /*
     /**********************************************************************
     /* Helper methods, setup


### PR DESCRIPTION
Blank strings for non-String fields were silently deserialized as undefined() instead of of(null), breaking PATCH semantics. Default remains false for backwards compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a module option to control how blank strings deserialize for non-String JsonNullable fields. When enabled, "" or "  " become JsonNullable.of(null) instead of undefined, restoring correct PATCH semantics. Default stays false for backward compatibility.

- **New Features**
  - JsonNullableModule.mapBlankStringToNull(boolean): if true, blank strings for non-String targets deserialize as JsonNullable.of(null). Strings are unaffected.
  - Configuration is passed through JsonNullableDeserializers and JsonNullableDeserializer; tests added.

- **Migration**
  - To enable: register new JsonNullableModule().mapBlankStringToNull(true).

<sup>Written for commit 67a328e5dd4c4f2a003d6f44f5faf05e477221cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

