### PR TITLE
Fix typo in Javadoc and code formatting

### DIFF
--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullable.java
@@ -89,7 +89,7 @@ public class JsonNullable<T> implements Serializable {
      * NoSuchElementException.
      *
      * @return the value of this JsonNullable
-     * @throws NoSuchElementException if no value if present
+     * @throws NoSuchElementException if no value is present
      *
      * @since 0.2.8
      */
@@ -117,7 +117,7 @@ public class JsonNullable<T> implements Serializable {
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> supplier)
         throws X
     {
-        if( this.isPresent ) {
+        if (this.isPresent) {
             return this.value;
         }
         throw supplier.get();
@@ -278,7 +278,7 @@ public class JsonNullable<T> implements Serializable {
      */
     @SuppressWarnings("unchecked")
     public JsonNullable<T> or( Supplier<? extends JsonNullable<? extends T>> supplier ) {
-        if( supplier == null ) {
+        if (supplier == null) {
             throw new NullPointerException("or supplier is null");
         }
         if (this.isPresent) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a typo in Javadoc and normalizes spacing in conditionals in `org.openapitools.jackson.nullable.JsonNullable` to improve readability. No behavior changes.

<sup>Written for commit b8059cc357c14a7357f28a799a401b1d9a3c0f9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

