### PR TITLE
Blank strings should not be deserialized as JsonNullable.undefined()  #125

### DIFF
--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableJackson2Deserializer.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableJackson2Deserializer.java
@@ -1,8 +1,6 @@
 package org.openapitools.jackson.nullable;
 
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -10,15 +8,10 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.std.ReferenceTypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
-import com.fasterxml.jackson.databind.type.ReferenceType;
-
-import java.io.IOException;
 
 public class JsonNullableJackson2Deserializer extends ReferenceTypeDeserializer<JsonNullable<Object>> {
 
     private static final long serialVersionUID = 1L;
-
-    private boolean isStringDeserializer = false;
 
     /*
     /**********************************************************
@@ -28,9 +21,6 @@ public class JsonNullableJackson2Deserializer extends ReferenceTypeDeserializer<
     public JsonNullableJackson2Deserializer(JavaType fullType, ValueInstantiator inst,
                                             TypeDeserializer typeDeser, JsonDeserializer<?> deser) {
         super(fullType, inst, typeDeser, deser);
-        if (fullType instanceof ReferenceType && ((ReferenceType) fullType).getReferencedType() != null) {
-            this.isStringDeserializer = ((ReferenceType) fullType).getReferencedType().isTypeOrSubTypeOf(String.class);
-        }
     }
 
     /*
@@ -38,18 +28,6 @@ public class JsonNullableJackson2Deserializer extends ReferenceTypeDeserializer<
     /* Abstract method implementations
     /**********************************************************
      */
-
-    @Override
-    public JsonNullable<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        JsonToken t = p.getCurrentToken();
-        if (t == JsonToken.VALUE_STRING && !isStringDeserializer) {
-            String str = p.getText().trim();
-            if (str.isEmpty()) {
-                return JsonNullable.undefined();
-            }
-        }
-        return super.deserialize(p, ctxt);
-    }
 
     @Override
     public JsonNullableJackson2Deserializer withResolved(TypeDeserializer typeDeser, JsonDeserializer<?> valueDeser) {

--- a/src/main/java/org/openapitools/jackson/nullable/JsonNullableJackson3Deserializer.java
+++ b/src/main/java/org/openapitools/jackson/nullable/JsonNullableJackson3Deserializer.java
@@ -1,9 +1,6 @@
 package org.openapitools.jackson.nullable;
 
 
-import tools.jackson.core.JacksonException;
-import tools.jackson.core.JsonParser;
-import tools.jackson.core.JsonToken;
 import tools.jackson.databind.DeserializationConfig;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JavaType;
@@ -11,12 +8,9 @@ import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.deser.ValueInstantiator;
 import tools.jackson.databind.deser.std.ReferenceTypeDeserializer;
 import tools.jackson.databind.jsontype.TypeDeserializer;
-import tools.jackson.databind.type.ReferenceType;
 
 public class JsonNullableJackson3Deserializer extends ReferenceTypeDeserializer<JsonNullable<Object>> {
 
-
-    private boolean isStringDeserializer = false;
 
     /*
     /**********************************************************
@@ -26,9 +20,6 @@ public class JsonNullableJackson3Deserializer extends ReferenceTypeDeserializer<
     public JsonNullableJackson3Deserializer(JavaType fullType, ValueInstantiator inst,
                                             TypeDeserializer typeDeser, ValueDeserializer<?> deser) {
         super(fullType, inst, typeDeser, deser);
-        if (fullType instanceof ReferenceType && ((ReferenceType) fullType).getReferencedType() != null) {
-            this.isStringDeserializer = ((ReferenceType) fullType).getReferencedType().isTypeOrSubTypeOf(String.class);
-        }
     }
 
     /*
@@ -36,18 +27,6 @@ public class JsonNullableJackson3Deserializer extends ReferenceTypeDeserializer<
     /* Abstract method implementations
     /**********************************************************
      */
-
-    @Override
-    public JsonNullable<Object> deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
-        JsonToken t = p.currentToken();
-        if (t == JsonToken.VALUE_STRING && !isStringDeserializer) {
-            String str = p.getString().trim();
-            if (str.isEmpty()) {
-                return JsonNullable.undefined();
-            }
-        }
-        return super.deserialize(p, ctxt);
-    }
 
     @Override
     protected ReferenceTypeDeserializer<JsonNullable<Object>> withResolved(TypeDeserializer typeDeser, ValueDeserializer<?> valueDeser) {

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullWithEmptyTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ParameterizedClass
@@ -36,7 +36,7 @@ class JsonNullWithEmptyTest extends ModuleTestBase {
     @Test
     void testJsonNullableFromEmpty() throws Exception {
         JsonNullable<?> value = jsonProcessor.readValue(quote(""), TypeReferences.INTEGER.getType(jsonProcessor));
-        assertFalse(value.isPresent());
+        assertEquals(JsonNullable.of(null), value);
     }
 
     // for [datatype-jdk8#23]
@@ -47,7 +47,7 @@ class JsonNullWithEmptyTest extends ModuleTestBase {
         BooleanBean b = jsonProcessor.readValue(aposToQuotes("{'value':''}"), BooleanBean.class);
         assertNotNull(b.value);
 
-        assertFalse(b.value.isPresent());
+        assertEquals(JsonNullable.of(null), b.value);
     }
 
     private enum TypeReferences {

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableBasicTest.java
@@ -349,7 +349,7 @@ class JsonNullableBasicTest extends ModuleTestBase {
     @Test
     void testDeserNull() throws Exception {
         JsonNullable<?> value = jsonProcessor.readValue("\"\"", TypeReferences.INTEGER.getType(jsonProcessor));
-        assertFalse(value.isPresent());
+        assertEquals(JsonNullable.of(null), value);
     }
 
     @Test

--- a/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/JsonNullableSimpleTest.java
@@ -144,8 +144,8 @@ final class JsonNullableSimpleTest {
     void deserializeNonStringMembers(JsonProcessor jsonProcessor) throws Exception {
         testReadPetAge(jsonProcessor, JsonNullable.of(Integer.valueOf(15)), "{\"age\":\"15\"}");
         testReadPetAge(jsonProcessor, JsonNullable.<Integer>of(null), "{\"age\":null}");
-        testReadPetAge(jsonProcessor, JsonNullable.<Integer>undefined(), "{\"age\":\"\"}");
-        testReadPetAge(jsonProcessor, JsonNullable.<Integer>undefined(), "{\"age\":\"   \"}");
+        testReadPetAge(jsonProcessor, JsonNullable.<Integer>of(null), "{\"age\":\"\"}");
+        testReadPetAge(jsonProcessor, JsonNullable.<Integer>of(null), "{\"age\":\"   \"}");
         testReadPetAge(jsonProcessor, JsonNullable.<Integer>undefined(), "{}");
     }
 
@@ -163,8 +163,8 @@ final class JsonNullableSimpleTest {
     void deserializeNonStringNonBeanMembers(JsonProcessor jsonProcessor) throws Exception {
         assertEquals(JsonNullable.of(null), jsonProcessor.readValue("\"null\"", TypeReferences.INTEGER.getType(jsonProcessor)));
         assertEquals(JsonNullable.of(42), jsonProcessor.readValue("\"42\"", TypeReferences.INTEGER.getType(jsonProcessor)));
-        assertEquals(JsonNullable.undefined(), jsonProcessor.readValue("\"\"", TypeReferences.INTEGER.getType(jsonProcessor)));
-        assertEquals(JsonNullable.undefined(), jsonProcessor.readValue("\"  \"", TypeReferences.INTEGER.getType(jsonProcessor)));
+        assertEquals(JsonNullable.of(null), jsonProcessor.readValue("\"\"", TypeReferences.INTEGER.getType(jsonProcessor)));
+        assertEquals(JsonNullable.of(null), jsonProcessor.readValue("\"  \"", TypeReferences.INTEGER.getType(jsonProcessor)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
addresses #125 

@wing328 I hope that works for you. If you want any changes, please let me know.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blank strings now deserialize to `JsonNullable.of(null)` (present null) instead of `JsonNullable.undefined()` for non-String types. Fixes #125 and aligns behavior with default deserialization.

- **Bug Fixes**
  - Removed the empty-string check from `JsonNullableJackson2Deserializer` and `JsonNullableJackson3Deserializer` to let blank strings coerce to null.
  - Updated tests to expect `JsonNullable.of(null)` for empty or whitespace strings; missing fields still yield `JsonNullable.undefined()`.

<sup>Written for commit 75b6cea69a378344beed17d8f4c04d91f47df0c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/jackson-databind-nullable/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

