### PR TITLE
0.2.11 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
     <packaging>jar</packaging>
     <name>JsonNullable Jackson module</name>
     <description>JsonNullable wrapper class and Jackson module to support fields with meaningful null values.</description>
-    <version>0.2.11-SNAPSHOT</version>
+    <version>0.2.11</version>
 
     <url>https://github.com/OpenAPITools/jackson-databind-nullable</url>
     <scm>
         <connection>scm:git:git@github.com:OpenAPITools/jackson-databind-nullable.git</connection>
         <developerConnection>scm:git:git@github.com:OpenAPITools/jackson-databind-nullable.git</developerConnection>
         <url>https://github.com/OpenAPITools/jackson-databind-nullable</url>
-        <tag>jackson-databind-nullable-0.2.11-SNAPSHOT</tag>
+        <tag>jackson-databind-nullable-0.2.11</tag>
     </scm>
     <licenses>
         <license>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promotes the module from 0.2.11-SNAPSHOT to the 0.2.11 release and updates the SCM tag to match, producing a stable artifact for publishing.

<sup>Written for commit ab12d7cdb3b03f64af45fc18f17c811de17c677c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/jackson-databind-nullable/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

