### PR TITLE
prepare 0.2.12 snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
     <packaging>jar</packaging>
     <name>JsonNullable Jackson module</name>
     <description>JsonNullable wrapper class and Jackson module to support fields with meaningful null values.</description>
-    <version>0.2.11</version>
+    <version>0.2.12-SNAPSHOT</version>
 
     <url>https://github.com/OpenAPITools/jackson-databind-nullable</url>
     <scm>
         <connection>scm:git:git@github.com:OpenAPITools/jackson-databind-nullable.git</connection>
         <developerConnection>scm:git:git@github.com:OpenAPITools/jackson-databind-nullable.git</developerConnection>
         <url>https://github.com/OpenAPITools/jackson-databind-nullable</url>
-        <tag>jackson-databind-nullable-0.2.11</tag>
+        <tag>jackson-databind-nullable-0.2.12-SNAPSHOT</tag>
     </scm>
     <licenses>
         <license>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the Maven project to 0.2.12-SNAPSHOT to start the next development cycle. Updates `pom.xml` version and sets `<scm><tag>` to `jackson-databind-nullable-0.2.12-SNAPSHOT`.

<sup>Written for commit 669f2d5be03dac3190b58fa2e75c14eb553a102b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/jackson-databind-nullable/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

