### PR TITLE
Enable CreatorTest and drop the stale @JsonCreator limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ assertEquals(JsonNullable.<String>undefined(), mapper.readValue("{}", Pet.class)
 
 ```
 
+`JsonNullable` can also be used as a `@JsonCreator` constructor parameter.
+An absent property is passed to the constructor as `JsonNullable.undefined()` rather than as `null`, so it stays distinguishable from an explicit `null`.
+
 The `ValueExtractor` is registered automatically via Java Service loader mechanism. The example class above will validate as follows
 ```java
 // instantiate javax.validation.Validator
@@ -89,6 +92,4 @@ assertEquals(1, validationResult.size());
 
 ## Limitations
 
-* Doesn't work when passed as a parameter to a `@JsonCreator` constructor (non present field gets deserialized as null instead of undefined).
-  But as JsonNullable is here to represent "optional" values, there shouldn't be a need to put it in a constructor.
 * Doesn't work with `@JsonUnwrapped`.

--- a/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
+++ b/src/test/java/org/openapitools/jackson/nullable/CreatorTest.java
@@ -2,19 +2,16 @@ package org.openapitools.jackson.nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-// TODO: fix JsonNullable in constructor annotated by JsonCreator
-@Disabled("JsonNullable in a constructor is deserialized to JsonNullable[null] instead of JsonNullable.undefined")
 class CreatorTest extends ModuleTestBase {
     static class CreatorWithJsonNullableStrings {
         JsonNullable<String> a, b;
 
-        // note: something weird with test setup, should not need annotations
+        // note: parameter names are not retained by default, hence the explicit @JsonProperty
         @JsonCreator
         public CreatorWithJsonNullableStrings(@JsonProperty("a") JsonNullable<String> a,
                                               @JsonProperty("b") JsonNullable<String> b) {
@@ -45,5 +42,21 @@ class CreatorTest extends ModuleTestBase {
         assertTrue(bean.a.isPresent());
         assertFalse(bean.b.isPresent());
         assertEquals("foo", bean.a.get());
+        assertEquals(JsonNullable.<String>undefined(), bean.b);
+    }
+
+    /**
+     * An absent creator property has to stay distinguishable from one that is
+     * explicitly set to <code>null</code>, which is the reason JsonNullable exists.
+     */
+    @ParameterizedTest
+    @MethodSource("jsonProcessors")
+    void testCreatorSeparatesExplicitNullFromAbsent(JsonProcessor jsonProcessor) throws Exception {
+        jsonProcessor.mapperWithModule();
+        CreatorWithJsonNullableStrings bean = jsonProcessor.readValue(
+                aposToQuotes("{'a':null}"), CreatorWithJsonNullableStrings.class);
+        assertNotNull(bean);
+        assertEquals(JsonNullable.<String>of(null), bean.a);
+        assertEquals(JsonNullable.<String>undefined(), bean.b);
     }
 }


### PR DESCRIPTION
## Summary

- Re-enable `CreatorTest`; the `getAbsentValue()` overrides added after the test was disabled now preserve `JsonNullable.undefined()` for absent creator properties.
- Add a regression case that distinguishes an explicit JSON `null` from an absent sibling property.
- Remove the stale `@JsonCreator` limitation from the README and document the supported behavior.

This changes tests and documentation only; it does not change production code.

## Verification

I ran:

```text
./mvnw -B clean verify -P integration-test
```

On JDK 25, the build completed successfully with 320 tests, 0 failures, 0 errors, and 3 expected `@JsonUnwrapped` skips. All three Maven Invoker integration builds passed.

The implementation session also performed a mutation check: removing either Jackson processor's `getAbsentValue()` override makes that processor's creator cases fail with the original symptom (`JsonNullable[null]` instead of `JsonNullable.undefined()`).

CI supplies the JDK 17 check that I could not reproduce locally.

## AI disclosure

Claude Opus 5 implemented and tested this change. OpenAI Codex independently reviewed the diff and reran the full build. David authorized this automated contribution workflow and owns the submission. The commit keeps an explicit `Co-Authored-By` trailer for Claude.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled `CreatorTest` and added a test to ensure absent `@JsonCreator` parameters deserialize as `JsonNullable.undefined()`, distinct from explicit nulls. Updated README to remove the stale `@JsonCreator` limitation and document the supported behavior; tests/docs only, no production code changes.

<sup>Written for commit c222afb4953e7255d68290d21136c0aece788638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/jackson-databind-nullable/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

