### PR TITLE
Test against JDK 17, 21 and 25 in CI

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -11,30 +11,38 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: Test (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 17 is the lowest JDK that can build this project: the Jackson 3
+        # dependency requires a Java 17 baseline and the multi-release build has
+        # a `release 17` compile execution. The Java 8 *target* stays covered by
+        # `<release>${java.version}</release>` on the default-compile execution.
+        java: [ 17, 21, 25 ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
-          java-version: 17
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Cache and restore Maven packages on master
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: ${{ github.ref_name == 'master' }}
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-m2-jdk${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-jdk${{ matrix.java }}
       - name: Restore Maven packages on PR
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: ${{ github.ref_name != 'master' }}
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-m2-jdk${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-jdk${{ matrix.java }}
       - name: Build and Test
         run: ./mvnw clean verify -P integration-test


### PR DESCRIPTION
Addresses the remaining unchecked Patch item in #74: "Test on Java 8 and latest Java version to ensure compatibility as versions are released".

### What changes

`.github/workflows/maven_test.yml` currently pins a single toolchain (`Set up JDK 17`, `java-version: 17`), so nothing catches a regression that only shows up on a newer JDK until a user reports it. This adds a `fail-fast: false` matrix over `java: [ 17, 21, 25 ]`, renames the job to `Test (JDK ${{ matrix.java }})` so the three legs are distinguishable in the checks list, and runs the existing `./mvnw clean verify -P integration-test` unchanged on each.

The Maven cache key gains a `jdk${{ matrix.java }}` segment (`${{ runner.os }}-m2-jdk17-<hash>` etc.). Without it the three parallel legs on `master` all try to save `${{ runner.os }}-m2-<hash>`, so two of the three `actions/cache` saves would collide on the same key ("Unable to reserve cache … already exists") and the legs would keep overwriting one shared entry. Cache behaviour on the GitHub runners is the one part of this change that can only be exercised once it runs on `master`.

Only the workflow file changes; no source, no `pom.xml`, no dependency versions.

### Why Java 8 is not in the matrix

The issue asks for a Java 8 leg, but the *toolchain* cannot be JDK 8 in this repo:

- `pom.xml` declares `compile-java-9` (`<release>9</release>`) and `compile-java-17` (`<release>17</release>`) executions for the multi-release jar, and `maven-javadoc-plugin` is configured with `<source>17</source>`.
- `tools.jackson.core:jackson-databind` 3.2.1 is a `provided`-scope dependency (so it is on the compile and test classpath) and Jackson 3 has a Java 17 baseline.

So 17 is the floor for building. The Java 8 *target* is already enforced independently of the toolchain by `<release>${java.version}</release>` (`java.version` = 8) on the `default-compile` execution — `--release 8` is what makes javac reject post-8 APIs, and it does that identically on a JDK 17, 21 or 25 toolchain. Adding a JDK 8 leg would not test anything the existing `release 8` setting does not already cover, and it cannot be done without dropping Jackson 3 support.

One thing the new legs surface that is worth knowing about: on JDK 21 and 25, javac emits `source value 8 is obsolete and will be removed in a future release` / `target value 8 is obsolete …` (2 occurrences each). JDK 17 does not. That is a warning today, but it is the signal for when the Java 8 target will actually need to be revisited, and having 21/25 in CI is what makes it visible.

### Verified

All three matrix legs were run locally with the exact workflow command, each on the matching Temurin JDK (macOS 27.0 / aarch64, not the ubuntu-latest runner):

- `./mvnw clean verify -P integration-test` on Temurin 17.0.20+8 — exit 0, `Tests run: 317, Failures: 0, Errors: 0, Skipped: 4`, invoker `Passed: 3, Failed: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS.
- Same command on Temurin 21.0.12+8 — exit 0, `Tests run: 317, Failures: 0, Errors: 0, Skipped: 4`, invoker `Passed: 3, Failed: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS.
- Same command on Temurin 25.0.1 — exit 0, `Tests run: 317, Failures: 0, Errors: 0, Skipped: 4`, invoker `Passed: 3, Failed: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS.

The workflow file also parses as YAML with the expected `strategy: {fail-fast: false, matrix: {java: [17, 21, 25]}}`.

Not verified locally: the cache hit/miss behaviour on the GitHub runners — that only exercises once this runs on `master`.

If you would rather keep CI to two legs (17 + latest) to hold runner minutes down, dropping `21` from the list is the only edit needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand CI to test on JDK 17, 21, and 25 to catch Java-version regressions and meet #74. Adds per-JDK cache keys and clearer job names; Maven command stays the same.

- **Refactors**
  - Adds matrix `java: [17, 21, 25]` with `fail-fast: false`; job renamed to "Test (JDK ${{ matrix.java }})".
  - Cache keys include `jdk${{ matrix.java }}` to avoid collisions across parallel runs.
  - JDK 17 is the build floor (multi-release build, `jackson-databind` 3.x); Java 8 target stays enforced via `--release 8`, so no JDK 8 CI leg.

<sup>Written for commit 7c176d6c7e50a27ad385368ed8fc59b3d04aee2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/jackson-databind-nullable/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

